### PR TITLE
Added ability to create relationships

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 
 <div class="tools form-inline well">
   <button class="btn" id="add_node_button"><i class="icon-plus"></i> Node</button>
+  <button class="btn" id="add_relationship_button"><i class="icon-plus"></i> Relationship</button>
   <button class="btn" id="exportMarkupButton">Export Markup</button>
   <button class="btn" id="exportSvgButton">Export SVG</button>
   <label for="internalScale">Internal Scale</label>
@@ -81,6 +82,12 @@
   <div class="modal-body">
     <div class="form-horizontal">
       <div class="control-group">
+        <label class="control-label" for="node_id">ID</label>
+        <div class="controls">
+          <input id="node_id" type="text" value="" disabled>
+        </div>
+      </div>
+      <div class="control-group">
         <label class="control-label" for="node_caption">Caption</label>
         <div class="controls">
           <input id="node_caption" type="text" value="A">
@@ -116,6 +123,18 @@
         </div>
       </div>
       <div class="control-group">
+        <label class="control-label" for="relationship_from">From Node</label>
+        <div class="controls">
+          <input id="relationship_from" type="text" value="">
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label" for="relationship_to">To Node</label>
+        <div class="controls">
+          <input id="relationship_to" type="text" value="">
+        </div>
+      </div>
+      <div class="control-group">
         <label class="control-label" for="relationship_properties">Properties</label>
         <div class="controls">
           <textarea id="relationship_properties" rows="6"></textarea>
@@ -126,6 +145,43 @@
   <div class="modal-footer">
     <a href="#" class="btn cancel">Cancel</a>
     <a href="#" class="btn btn-primary" id="edit_relationship_save">Save</a>
+  </div>
+</div>
+<div class="modal hide pop-up-editor newrelationship" tabindex="-1">
+  <div class="modal-header">
+    <h3>Create Relationship</h3>
+  </div>
+  <div class="modal-body">
+    <div class="form-horizontal">
+      <div class="control-group">
+        <label class="control-label" for="newrelationship_type">Type</label>
+        <div class="controls">
+          <input id="newrelationship_type" type="text" value="R">
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label" for="newrelationship_from">From Node</label>
+        <div class="controls">
+          <input id="newrelationship_from" type="text" value="0">
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label" for="newrelationship_to">To Node</label>
+        <div class="controls">
+          <input id="newrelationship_to" type="text" value="1">
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label" for="newrelationship_properties">Properties</label>
+        <div class="controls">
+          <textarea id="newrelationship_properties" rows="6"></textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <a href="#" class="btn cancel">Cancel</a>
+    <a href="#" class="btn btn-primary" id="new_relationship_save">Save</a>
   </div>
 </div>
 


### PR DESCRIPTION
I love your tool, I find it very useful to prepare graphs for blog posts about neo4j, but one thing I was missing was the ability to create new relationships, so I decided to fork your repo and add this piece of functionality. This was my first time forking a repo, so I am not sure if I am doing everything right. Also I didn't have too much time to test it, but it seems to be working fine.

I added an ID field to the nodes, so when you double click on them you can see the node ID.

![screen shot 2014-01-09 at 14 19 02](https://f.cloud.github.com/assets/3496428/1877882/c915bca8-7930-11e3-8bb7-c3836f7d38e9.png)

Then, let's say you want to add a new relationship "R" between node 3 and node 5, all you have to do is click on the "+ relationship" button and enter 3 as the FROM node and 5 as the TO node. 

![screen shot 2014-01-09 at 14 19 24](https://f.cloud.github.com/assets/3496428/1877885/d0a5506e-7930-11e3-8350-b8d1cb4d4f0b.png)

I also added these fields in the edit relationship modal so you can change or move a relationship easily

![screen shot 2014-01-09 at 14 19 56](https://f.cloud.github.com/assets/3496428/1877886/d5282d46-7930-11e3-9264-ed38d3805b21.png)
