### PR TITLE
Allow property values with colons in them

### DIFF
--- a/graph-editor.js
+++ b/graph-editor.js
@@ -213,10 +213,10 @@ window.onload = function()
             node.caption( captionField.node().value );
             node.properties().clearAll();
             propertiesField.node().value.split("\n").forEach(function(line) {
-                var tokens = line.split(/: */);
-                if (tokens.length === 2) {
-                    var key = tokens[0].trim();
-                    var value = tokens[1].trim();
+                var index = line.indexOf(":");
+                if(index !== -1) {
+                    var key = line.substring(0, index).trim();
+                    var value = line.substring(index + 1).trim();
                     if (key.length > 0 && value.length > 0) {
                         node.properties().set(key, value);
                     }

--- a/graph-editor.js
+++ b/graph-editor.js
@@ -214,7 +214,7 @@ window.onload = function()
             node.properties().clearAll();
             propertiesField.node().value.split("\n").forEach(function(line) {
                 var index = line.indexOf(":");
-                if(index !== -1) {
+                if (index !== -1) {
                     var key = line.substring(0, index).trim();
                     var value = line.substring(index + 1).trim();
                     if (key.length > 0 && value.length > 0) {


### PR DESCRIPTION
Simple change to allows node properties to contain colons.

For example, in the following list:
```
uuid: aa2d5b91-575f-4c03-b53a-16e9721c3903
name: Neo4j
url: https://neo4j.com
```
the `url` property would have been ignored after selecting `Save` due to the colon in the URL.