### PR TITLE
fix: add utf8-support.

### DIFF
--- a/graph-editor.js
+++ b/graph-editor.js
@@ -365,7 +365,7 @@ window.onload = function()
 
     function updateSvgDownloadLink() {
       var rawSvg = new XMLSerializer().serializeToString(d3.select("#canvas svg" ).node());
-      d3.select("#downloadSvgButton").attr('href', "data:image/svg+xml;base64," + btoa( rawSvg ));
+      d3.select("#downloadSvgButton").attr('href', "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent( rawSvg ))));
     }
 
     var openConsoleWithCypher = function (evt)


### PR DESCRIPTION
When we have utf-8 characters, this error is occured and with this error, the user can't do anything because the nodes stick to the cursor.

`Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.`

I fixed the error with the help of [stackOverFlow](https://stackoverflow.com/questions/23223718/failed-to-execute-btoa-on-window-the-string-to-be-encoded-contains-characte) :) 